### PR TITLE
feat: add Uptime Kuma uptime monitoring service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,7 @@ SEARXNG_HOSTNAME=searxng.yourdomain.com
 SUPABASE_HOSTNAME=supabase.yourdomain.com
 WAHA_HOSTNAME=waha.yourdomain.com
 WEAVIATE_HOSTNAME=weaviate.yourdomain.com
+UPTIME_KUMA_HOSTNME=uptime-kuma.yourdomain.com
 WEBUI_HOSTNAME=webui.yourdomain.com
 WELCOME_HOSTNAME=welcome.yourdomain.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Uptime Kuma** - Self-hosted uptime monitoring with 90+ notification services
+
 ## [1.3.3] - 2026-02-27
 
 ### Fixed

--- a/Caddyfile
+++ b/Caddyfile
@@ -107,6 +107,11 @@ import /etc/caddy/addons/tls-snippet.conf
     reverse_proxy temporal-ui:8080
 }
 
+# Uptime Kuma
+{$UPTIME_KUMA_HOSTNAME} {
+    reverse_proxy uptimekuma:3001
+}
+
 # Databasus
 {$DATABASUS_HOSTNAME} {
     import service_tls

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The installer also makes the following powerful open-source tools **available fo
 
 ✅ [**Supabase**](https://supabase.com/) - An open-source alternative to Firebase, providing database storage, user authentication, and more. It's a popular choice for AI applications.
 
+✅ [**Uptime Kuma**](https://github.com/louislam/uptime-kuma - Self-hosted uptime monitoring tool with notifications
+
 ✅ [**WAHA**](https://waha.devlike.pro/) - WhatsApp HTTP API (REST API) that you can configure in a click! 3 engines: WEBJS (browser based), NOWEB (websocket nodejs), GOWS (websocket go).
 
 ✅ [**Weaviate**](https://weaviate.io/) - An open-source AI-native vector database with a focus on scalability and ease of use. It can be used for RAG, hybrid search, and more.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1276,3 +1276,18 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: uptime-kuma
+    profiles: ["uptime-kuma"]
+    restart: unless-stopped
+    environment:
+      UPTIME_KUMA_WS_ORIGIN_CHECK: bypass
+    volumes:
+      - uptime_kuma_data:/app/database
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/scripts/04_wizard.sh
+++ b/scripts/04_wizard.sh
@@ -67,6 +67,7 @@ base_services_data=(
     "ragflow" "RAGFlow (Deep document understanding RAG engine)"
     "searxng" "SearXNG (Private Metasearch Engine)"
     "supabase" "Supabase (Backend as a Service)"
+    "uptimekuma" "Uptime Kuma (Uptime Monitoring)"
     "waha" "WAHA – WhatsApp HTTP API (NOWEB engine)"
     "weaviate" "Weaviate (Vector Database with API Key Auth)"
 )

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -103,6 +103,9 @@ fi
 if is_profile_active "postiz"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Postiz${NC}: Create your account on first login"
 fi
+if is_profile_active "uptime_kuma"; then
+    echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Register your account on first login"
+fi
 if is_profile_active "gost"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Gost Proxy${NC}: Routing AI traffic through external proxy"
 fi

--- a/scripts/generate_welcome_page.sh
+++ b/scripts/generate_welcome_page.sh
@@ -354,6 +354,16 @@ if is_profile_active "postiz"; then
     }")
 fi
 
+# Uptime Kuma
+if is_profile_active "uptime-kuma"; then
+    SERVICES_ARRAY+=("    \"uptime-kuma\": {
+      \"hostname\": \"$(json_escape "$UPTIMEKUMA_HOSTNAME")\",
+      \"credentials\": {
+        \"note\": \"Create account on first login\"
+      }
+    }")
+fi
+
 # WAHA
 if is_profile_active "waha"; then
     SERVICES_ARRAY+=("    \"waha\": {

--- a/welcome/app.js
+++ b/welcome/app.js
@@ -420,6 +420,14 @@
             category: 'tools',
             docsUrl: 'https://docs.python.org'
         },
+        'uptime-kuma': {
+            name: 'Uptime Kuma',
+            description: 'Uptime Monitoring Dashboard',
+            icon: 'UK',
+            color: 'bg-[#5CDD8B]',
+            category: 'monitoring',
+            docsUrl: 'https://github.com/louislam/uptime-kuma'
+        }
         'cloudflare-tunnel': {
             name: 'Cloudflare Tunnel',
             description: 'Zero-Trust Network Access',


### PR DESCRIPTION
## Summary
- Add **Uptime Kuma** as a new optional service (`uptime-kuma` profile)
- Self-hosted uptime monitoring with 90+ notification services (62k+ GitHub stars)
- Single container, built-in auth (no Caddy basic auth needed), SQLite storage, WebSocket support

## Changes
- `docker-compose.yml`: Add uptime-kuma service with healthcheck, volume
- `Caddyfile`: Add reverse proxy block for Uptime Kuma
- `.env.example`: Add hostname variable
- `scripts/04_wizard.sh`: Add to service selection wizard
- `scripts/generate_welcome_page.sh`: Add to welcome dashboard
- `welcome/app.js`: Add SERVICE_METADATA entry
- `scripts/07_final_report.sh`: Add post-install report output
- `README.md`: Add to "What's Included" list
- `CHANGELOG.md`: Add changelog entry

## Test plan
- [ ] Verify `docker compose -p localai config --quiet` passes
- [ ] Run installation wizard and select Uptime Kuma
- [ ] Verify container starts and healthcheck passes
- [ ] Verify Caddy reverse proxy routes correctly
- [ ] Verify welcome page shows Uptime Kuma entry
- [ ] Verify final report displays Uptime Kuma info

🤖 Generated with [Claude Code](https://claude.com/claude-code)