### PR TITLE
feat: add Uptime Kuma uptime monitoring service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,7 @@ SEARXNG_HOSTNAME=searxng.yourdomain.com
 SUPABASE_HOSTNAME=supabase.yourdomain.com
 WAHA_HOSTNAME=waha.yourdomain.com
 WEAVIATE_HOSTNAME=weaviate.yourdomain.com
+UPTIME_KUMA_HOSTNME=uptime-kuma.yourdomain.com
 WEBUI_HOSTNAME=webui.yourdomain.com
 WELCOME_HOSTNAME=welcome.yourdomain.com
 

--- a/.env.example
+++ b/.env.example
@@ -183,7 +183,7 @@ SEARXNG_HOSTNAME=searxng.yourdomain.com
 SUPABASE_HOSTNAME=supabase.yourdomain.com
 WAHA_HOSTNAME=waha.yourdomain.com
 WEAVIATE_HOSTNAME=weaviate.yourdomain.com
-UPTIME_KUMA_HOSTNME=uptime-kuma.yourdomain.com
+UPTIME_KUMA_HOSTNAME=uptime-kuma.yourdomain.com
 WEBUI_HOSTNAME=webui.yourdomain.com
 WELCOME_HOSTNAME=welcome.yourdomain.com
 
@@ -447,7 +447,7 @@ GOST_UPSTREAM_PROXY=
 
 # Internal services bypass list (prevents internal Docker traffic from going through proxy)
 # Includes: Docker internal networks (172.16-31.*, 10.*), Docker DNS (127.0.0.11), and all service hostnames
-GOST_NO_PROXY=localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.local,appsmith,postgres,postgres:5432,redis,redis:6379,caddy,ollama,neo4j,qdrant,weaviate,clickhouse,minio,searxng,crawl4ai,gotenberg,langfuse-web,langfuse-worker,flowise,n8n,n8n-import,n8n-worker-1,n8n-worker-2,n8n-worker-3,n8n-worker-4,n8n-worker-5,n8n-worker-6,n8n-worker-7,n8n-worker-8,n8n-worker-9,n8n-worker-10,n8n-runner-1,n8n-runner-2,n8n-runner-3,n8n-runner-4,n8n-runner-5,n8n-runner-6,n8n-runner-7,n8n-runner-8,n8n-runner-9,n8n-runner-10,letta,lightrag,docling,postiz,temporal,temporal-ui,ragflow,ragflow-mysql,ragflow-minio,ragflow-redis,ragflow-elasticsearch,ragapp,open-webui,comfyui,waha,libretranslate,paddleocr,nocodb,db,studio,kong,auth,rest,realtime,storage,imgproxy,meta,functions,analytics,vector,supavisor,gost,api.telegram.org,telegram.org,t.me,core.telegram.org
+GOST_NO_PROXY=localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.local,appsmith,postgres,postgres:5432,redis,redis:6379,caddy,ollama,neo4j,qdrant,weaviate,clickhouse,minio,searxng,crawl4ai,gotenberg,langfuse-web,langfuse-worker,flowise,n8n,n8n-import,n8n-worker-1,n8n-worker-2,n8n-worker-3,n8n-worker-4,n8n-worker-5,n8n-worker-6,n8n-worker-7,n8n-worker-8,n8n-worker-9,n8n-worker-10,n8n-runner-1,n8n-runner-2,n8n-runner-3,n8n-runner-4,n8n-runner-5,n8n-runner-6,n8n-runner-7,n8n-runner-8,n8n-runner-9,n8n-runner-10,letta,lightrag,docling,postiz,temporal,temporal-ui,ragflow,ragflow-mysql,ragflow-minio,ragflow-redis,ragflow-elasticsearch,ragapp,open-webui,comfyui,waha,libretranslate,paddleocr,nocodb,db,studio,kong,auth,rest,realtime,storage,imgproxy,meta,functions,analytics,vector,supavisor,gost,uptime-kuma,api.telegram.org,telegram.org,t.me,core.telegram.org
 
 ############
 # Functions - Configuration for Functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Uptime Kuma** - Self-hosted uptime monitoring with 90+ notification services
+
 ## [1.3.3] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 - **Uptime Kuma** - Self-hosted uptime monitoring with 90+ notification services
 
 ## [1.3.3] - 2026-02-27

--- a/Caddyfile
+++ b/Caddyfile
@@ -109,7 +109,8 @@ import /etc/caddy/addons/tls-snippet.conf
 
 # Uptime Kuma
 {$UPTIME_KUMA_HOSTNAME} {
-    reverse_proxy uptimekuma:3001
+    import service_tls
+    reverse_proxy uptime-kuma:3001
 }
 
 # Databasus

--- a/Caddyfile
+++ b/Caddyfile
@@ -107,6 +107,11 @@ import /etc/caddy/addons/tls-snippet.conf
     reverse_proxy temporal-ui:8080
 }
 
+# Uptime Kuma
+{$UPTIME_KUMA_HOSTNAME} {
+    reverse_proxy uptimekuma:3001
+}
+
 # Databasus
 {$DATABASUS_HOSTNAME} {
     import service_tls

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The installer also makes the following powerful open-source tools **available fo
 
 ✅ [**Supabase**](https://supabase.com/) - An open-source alternative to Firebase, providing database storage, user authentication, and more. It's a popular choice for AI applications.
 
-✅ [**Uptime Kuma**](https://github.com/louislam/uptime-kuma - Self-hosted uptime monitoring tool with notifications
+✅ [**Uptime Kuma**](https://github.com/louislam/uptime-kuma) - Self-hosted uptime monitoring tool with notifications
 
 ✅ [**WAHA**](https://waha.devlike.pro/) - WhatsApp HTTP API (REST API) that you can configure in a click! 3 engines: WEBJS (browser based), NOWEB (websocket nodejs), GOWS (websocket go).
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The installer also makes the following powerful open-source tools **available fo
 
 ✅ [**Supabase**](https://supabase.com/) - An open-source alternative to Firebase, providing database storage, user authentication, and more. It's a popular choice for AI applications.
 
+✅ [**Uptime Kuma**](https://github.com/louislam/uptime-kuma - Self-hosted uptime monitoring tool with notifications
+
 ✅ [**WAHA**](https://waha.devlike.pro/) - WhatsApp HTTP API (REST API) that you can configure in a click! 3 engines: WEBJS (browser based), NOWEB (websocket nodejs), GOWS (websocket go).
 
 ✅ [**Weaviate**](https://weaviate.io/) - An open-source AI-native vector database with a focus on scalability and ease of use. It can be used for RAG, hybrid search, and more.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ volumes:
   ragflow_redis_data:
   temporal_elasticsearch_data:
   valkey-data:
+  uptime_kuma_data:
   weaviate_data:
 
 # Shared logging configuration for services
@@ -380,6 +381,7 @@ services:
       SEARXNG_PASSWORD_HASH: ${SEARXNG_PASSWORD_HASH}
       SEARXNG_USERNAME: ${SEARXNG_USERNAME}
       SUPABASE_HOSTNAME: ${SUPABASE_HOSTNAME}
+      UPTIME_KUMA_HOSTNAME: ${UPTIME_KUMA_HOSTNAME}
       WAHA_HOSTNAME: ${WAHA_HOSTNAME}
       WEAVIATE_HOSTNAME: ${WEAVIATE_HOSTNAME}
       WEBUI_HOSTNAME: ${WEBUI_HOSTNAME}
@@ -1282,12 +1284,13 @@ services:
     container_name: uptime-kuma
     profiles: ["uptime-kuma"]
     restart: unless-stopped
+    logging: *default-logging
     environment:
       UPTIME_KUMA_WS_ORIGIN_CHECK: bypass
     volumes:
-      - uptime_kuma_data:/app/database
+      - uptime_kuma_data:/app/data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1276,3 +1276,18 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: uptime-kuma
+    profiles: ["uptime-kuma"]
+    restart: unless-stopped
+    environment:
+      UPTIME_KUMA_WS_ORIGIN_CHECK: bypass
+    volumes:
+      - uptime_kuma_data:/app/database
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1294,3 +1294,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1286,11 +1286,12 @@ services:
     restart: unless-stopped
     logging: *default-logging
     environment:
+      <<: *proxy-env
       UPTIME_KUMA_WS_ORIGIN_CHECK: bypass
     volumes:
       - uptime_kuma_data:/app/data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/ || exit 1"]
+      test: ["CMD-SHELL", "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= wget -qO- http://localhost:3001/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/scripts/04_wizard.sh
+++ b/scripts/04_wizard.sh
@@ -67,6 +67,7 @@ base_services_data=(
     "ragflow" "RAGFlow (Deep document understanding RAG engine)"
     "searxng" "SearXNG (Private Metasearch Engine)"
     "supabase" "Supabase (Backend as a Service)"
+    "uptimekuma" "Uptime Kuma (Uptime Monitoring)"
     "waha" "WAHA – WhatsApp HTTP API (NOWEB engine)"
     "weaviate" "Weaviate (Vector Database with API Key Auth)"
 )

--- a/scripts/04_wizard.sh
+++ b/scripts/04_wizard.sh
@@ -67,7 +67,7 @@ base_services_data=(
     "ragflow" "RAGFlow (Deep document understanding RAG engine)"
     "searxng" "SearXNG (Private Metasearch Engine)"
     "supabase" "Supabase (Backend as a Service)"
-    "uptimekuma" "Uptime Kuma (Uptime Monitoring)"
+    "uptime-kuma" "Uptime Kuma (Uptime Monitoring)"
     "waha" "WAHA – WhatsApp HTTP API (NOWEB engine)"
     "weaviate" "Weaviate (Vector Database with API Key Auth)"
 )

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -104,7 +104,7 @@ if is_profile_active "postiz"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Postiz${NC}: Create your account on first login"
 fi
 if is_profile_active "uptime-kuma"; then
-    echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Register your account on first login"
+    echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Create your account on first login"
 fi
 if is_profile_active "gost"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Gost Proxy${NC}: Routing AI traffic through external proxy"

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -103,7 +103,7 @@ fi
 if is_profile_active "postiz"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Postiz${NC}: Create your account on first login"
 fi
-if is_profile_active "uptime_kuma"; then
+if is_profile_active "uptime-kuma"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Register your account on first login"
 fi
 if is_profile_active "gost"; then

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -103,6 +103,9 @@ fi
 if is_profile_active "postiz"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Postiz${NC}: Create your account on first login"
 fi
+if is_profile_active "uptime_kuma"; then
+    echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Register your account on first login"
+fi
 if is_profile_active "gost"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Gost Proxy${NC}: Routing AI traffic through external proxy"
 fi

--- a/scripts/generate_welcome_page.sh
+++ b/scripts/generate_welcome_page.sh
@@ -357,7 +357,7 @@ fi
 # Uptime Kuma
 if is_profile_active "uptime-kuma"; then
     SERVICES_ARRAY+=("    \"uptime-kuma\": {
-      \"hostname\": \"$(json_escape "$UPTIMEKUMA_HOSTNAME")\",
+      \"hostname\": \"$(json_escape "$UPTIME_KUMA_HOSTNAME")\",
       \"credentials\": {
         \"note\": \"Create account on first login\"
       }

--- a/scripts/generate_welcome_page.sh
+++ b/scripts/generate_welcome_page.sh
@@ -354,6 +354,16 @@ if is_profile_active "postiz"; then
     }")
 fi
 
+# Uptime Kuma
+if is_profile_active "uptime-kuma"; then
+    SERVICES_ARRAY+=("    \"uptime-kuma\": {
+      \"hostname\": \"$(json_escape "$UPTIMEKUMA_HOSTNAME")\",
+      \"credentials\": {
+        \"note\": \"Create account on first login\"
+      }
+    }")
+fi
+
 # WAHA
 if is_profile_active "waha"; then
     SERVICES_ARRAY+=("    \"waha\": {

--- a/welcome/app.js
+++ b/welcome/app.js
@@ -420,6 +420,14 @@
             category: 'tools',
             docsUrl: 'https://docs.python.org'
         },
+        'uptime-kuma': {
+            name: 'Uptime Kuma',
+            description: 'Uptime Monitoring Dashboard',
+            icon: 'UK',
+            color: 'bg-[#5CDD8B]',
+            category: 'monitoring',
+            docsUrl: 'https://github.com/louislam/uptime-kuma'
+        }
         'cloudflare-tunnel': {
             name: 'Cloudflare Tunnel',
             description: 'Zero-Trust Network Access',

--- a/welcome/app.js
+++ b/welcome/app.js
@@ -427,7 +427,7 @@
             color: 'bg-[#5CDD8B]',
             category: 'monitoring',
             docsUrl: 'https://github.com/louislam/uptime-kuma'
-        }
+        },
         'cloudflare-tunnel': {
             name: 'Cloudflare Tunnel',
             description: 'Zero-Trust Network Access',


### PR DESCRIPTION
## Summary
- Add Uptime Kuma self-hosted uptime monitoring with 90+ notification services
- Includes Docker Compose service, Caddy reverse proxy, wizard integration, welcome page, and final report
- Fix 15 integration errors (healthcheck port, logging, TLS, hostname typo, volume config, profile names, etc.)

## Test plan
- [ ] Verify `docker compose -p localai config --quiet` passes
- [ ] Run installation wizard and confirm Uptime Kuma appears with correct profile name
- [ ] Start stack with `uptime-kuma` profile and verify container is healthy
- [ ] Confirm Caddy proxies traffic to Uptime Kuma via configured hostname
- [ ] Check welcome page shows Uptime Kuma with correct hostname
- [ ] Verify final report displays Uptime Kuma info when profile is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Uptime Kuma as an optional monitoring service for tracking uptime across your infrastructure with support for 90+ notification services.
  * Integrated Uptime Kuma into the setup wizard for easy enablement during deployment.
  * Added routing configuration and documentation for the new monitoring solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->