### PR TITLE
fix: keep python-runner alive by default to stop restart loop (#87)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1074,8 +1074,10 @@ services:
     container_name: python-runner
     profiles: ["python-runner"]
     restart: unless-stopped
+    # init + exec make SIGTERM reach python so the container stops fast
+    init: true
     working_dir: /app
-    command: /bin/sh -c 'if [ -f /app/requirements.txt ]; then python -m pip install --no-cache-dir -r /app/requirements.txt; fi; python /app/main.py'
+    command: /bin/sh -c 'if [ -f /app/requirements.txt ]; then python -m pip install --no-cache-dir -r /app/requirements.txt; fi; exec python /app/main.py'
     volumes:
       - ./python-runner:/app
 

--- a/python-runner/main.py
+++ b/python-runner/main.py
@@ -1,3 +1,10 @@
-print("Python runner is up!")
+# Default entry point for the Python Runner service.
+# Replace this file with your own long-running code.
+# The idle loop below keeps the container alive so Docker's
+# `restart: unless-stopped` policy does not restart it endlessly.
+import time
 
+print("Python runner is up!", flush=True)
 
+while True:
+    time.sleep(3600)


### PR DESCRIPTION
## Summary

The default `python-runner/main.py` printed one line and exited with code 0. Because the service uses `restart: unless-stopped`, Docker restarted the container forever, and `make doctor` flagged it with a false "has restarted N times" warning on every default install.

## What changed

- **python-runner/main.py**: the default script now prints the startup message (with `flush=True` so it reaches `docker logs`) and then idles in a `time.sleep` loop, keeping the container running. Users still replace this file with their own code; `python-runner/` is in `PRESERVE_DIRS`, so existing custom scripts survive updates.
- **docker-compose.yml** (python-runner service): added `init: true` and `exec` before `python /app/main.py`. Without this, SIGTERM stopped at the `sh -c` wrapper (PID 1) and the idling python process never received it, so every `make stop`/`restart`/update waited out the 10s grace period before SIGKILL. With tini as PID 1 and `exec`, the container now stops immediately. This also benefits users' custom long-running scripts.

No changes to `doctor.sh` were needed: once the container stays up, its restart count stops growing, and the update/restart flows recreate containers (`docker compose down`), which resets any existing count to 0.

## Verification

- `python3 -c "import ast; ast.parse(open('python-runner/main.py').read())"` — syntax OK.
- `docker-compose.yml` parses as valid YAML.
- Docker is not available on the dev machine, so the runtime check is by reasoning: the process blocks in `time.sleep` inside `while True` and never exits, so `restart: unless-stopped` has nothing to restart; tini forwards SIGTERM to the exec'd python process for clean, fast shutdown.
- Reviewed with the PR review toolkit; the one important finding (slow SIGTERM shutdown) was fixed in the second commit.

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8