### PR TITLE
fix: make Crawl4AI reachable from other containers (#84)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,16 @@ OLLAMA_CADDY_API_TOKEN=
 
 ############
 # [required]
+# Crawl4AI API Bearer token (auto-generated)
+# Crawl4AI 0.9+ binds loopback only without a token, making it unreachable
+# from other containers. With a token it listens on the Docker network.
+# Requests to http://crawl4ai:11235 must send: Authorization: Bearer <this value>
+############
+CRAWL4AI_API_TOKEN=
+
+
+############
+# [required]
 # Neo4j username and password
 ############
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -766,6 +766,9 @@ services:
       - .env
     environment:
       <<: *proxy-env
+      # Without a token Crawl4AI 0.9+ binds 127.0.0.1 only and is unreachable
+      # from other containers; with it the API listens on the Docker network.
+      CRAWL4AI_API_TOKEN: "${CRAWL4AI_API_TOKEN}"
     deploy:
       resources:
         limits:

--- a/scripts/03_generate_secrets.sh
+++ b/scripts/03_generate_secrets.sh
@@ -80,6 +80,7 @@ declare -A VARS_TO_GENERATE=(
     ["APPSMITH_ENCRYPTION_SALT"]="password:32"
     ["CLICKHOUSE_PASSWORD"]="password:32"
     ["COMFYUI_PASSWORD"]="password:32" # Added ComfyUI basic auth password
+    ["CRAWL4AI_API_TOKEN"]="secret:48" # Bearer token; Crawl4AI 0.9+ binds loopback only without it
     ["DASHBOARD_PASSWORD"]="password:32" # Supabase Dashboard
     ["DIFY_SECRET_KEY"]="secret:64" # Dify application secret key (maps to SECRET_KEY in Dify)
     ["DOCLING_PASSWORD"]="password:32"

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -115,6 +115,9 @@ fi
 if is_profile_active "cpu" || is_profile_active "gpu-nvidia" || is_profile_active "gpu-amd"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Ollama API${NC}: To expose externally, point DNS at ${OLLAMA_HOSTNAME:-<OLLAMA_HOSTNAME>} and send 'Authorization: Bearer <token>' (see Welcome Page)"
 fi
+if is_profile_active "crawl4ai"; then
+    echo -e "     ${GREEN}*${NC} ${WHITE}Crawl4AI${NC}: Internal API at http://crawl4ai:11235 - requests must send 'Authorization: Bearer <token>' (token on Welcome Page)"
+fi
 if is_profile_active "invokeai-nvidia" || is_profile_active "invokeai-amd" || is_profile_active "invokeai-cpu"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}InvokeAI${NC}: Open the Model Manager on first visit and download a starter model before generating images"
 fi

--- a/scripts/generate_welcome_page.sh
+++ b/scripts/generate_welcome_page.sh
@@ -418,10 +418,11 @@ if is_profile_active "crawl4ai"; then
     SERVICES_ARRAY+=("    \"crawl4ai\": {
       \"hostname\": null,
       \"credentials\": {
-        \"note\": \"Internal service only\"
+        \"api_token\": \"$(json_escape "$CRAWL4AI_API_TOKEN")\"
       },
       \"extra\": {
-        \"internal_api\": \"http://crawl4ai:11235\"
+        \"internal_api\": \"http://crawl4ai:11235\",
+        \"recommendation\": \"Requests must send header: Authorization: Bearer <API Token>\"
       }
     }")
 fi


### PR DESCRIPTION
## Summary

Crawl4AI 0.9+ refuses to bind anything but `127.0.0.1` when no credential is configured. Its entrypoint hardcodes the loopback bind in the no-token branch, so there is no upstream env var to bind `0.0.0.0` without a token. As a result, n8n, Flowise, and other containers got `ECONNREFUSED` when calling `http://crawl4ai:11235`.

This PR follows the approach proposed in the issue: auto-generate `CRAWL4AI_API_TOKEN` like other secrets (same pattern as `OLLAMA_CADDY_API_TOKEN` and `HERMES_API_SERVER_KEY`). With a token present, Crawl4AI binds all interfaces and is reachable on the Docker network.

## What changed

- `.env.example`: new `CRAWL4AI_API_TOKEN=` section explaining the loopback-bind behavior
- `scripts/03_generate_secrets.sh`: `CRAWL4AI_API_TOKEN` added to `VARS_TO_GENERATE` (`secret:48`), so it is generated on fresh install and backfilled automatically on `make update` for existing installs
- `docker-compose.yml`: token passed explicitly in the `crawl4ai` service environment
- `scripts/generate_welcome_page.sh`: welcome page now shows the API token and a note that requests need the Bearer header (rendered by the existing `api_token`/`recommendation` handling in `welcome/app.js`, no JS change needed)
- `scripts/07_final_report.sh`: post-install note for the `crawl4ai` profile pointing to the internal URL and the Welcome Page token

Note for users: clients calling Crawl4AI from n8n or other services must now send the header `Authorization: Bearer <CRAWL4AI_API_TOKEN>`. The health endpoint stays public.

## Verification

- `bash -n` passes on all changed scripts
- `docker compose -p localai config --quiet` passes with a `.env` copied from `.env.example`; the rendered `crawl4ai` service config contains `CRAWL4AI_API_TOKEN`
- `scripts/generate_welcome_page.sh` run with the `crawl4ai` profile produces valid JSON with the token and the Bearer-header note
- Traced `scripts/03_generate_secrets.sh`: a missing `CRAWL4AI_API_TOKEN` in an existing `.env` gets generated on update without touching existing values
- Upstream `unclecode/crawl4ai` `deploy/docker/entrypoint.sh` confirmed: no token means forced `127.0.0.1` bind (no override honored); token present means bind on all interfaces, auth gate requires `Authorization: Bearer <token>` on all non-public routes

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8