### PR TITLE
fix: repair broken healthchecks for six services (#85)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
     volumes:
       - appsmith_data:/appsmith-stacks
     healthcheck:
-      test: ["CMD-SHELL", "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= wget -qO- http://localhost/api/v1/health || exit 1"]
+      test: ["CMD-SHELL", "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= curl -fsS http://localhost/api/v1/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -780,7 +780,7 @@ services:
     environment:
       DISABLE_GOOGLE_CHROME: false
     healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:3000/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -1020,7 +1020,7 @@ services:
     volumes:
       - databasus_data:/databasus-data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:4005/ || exit 1"]
+      test: ["CMD", "databasus", "healthcheck"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -1036,7 +1036,7 @@ services:
     volumes:
       - comfyui_data:/home/runner
     healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8188"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8188', timeout=5)"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -1097,7 +1097,7 @@ services:
       - paddlex_data:/root/.paddlex
     healthcheck:
       test:
-        ["CMD-SHELL", "wget -qO- http://localhost:8080 > /dev/null || exit 1"]
+        ["CMD-SHELL", "wget -qO- http://localhost:8080/health > /dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -1342,7 +1342,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= wget -qO- http://localhost:9621/health > /dev/null 2>&1 || exit 1",
+          "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= python -c \"import urllib.request; urllib.request.urlopen('http://localhost:9621/health', timeout=5)\" > /dev/null 2>&1 || exit 1",
         ]
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
## Summary

Six services were reported as `unhealthy` even when they worked fine. Their healthchecks called `wget`, which does not exist in five of the images, and PaddleOCR probed the wrong endpoint (`/` returns 404). This PR replaces each broken probe with a tool that is verified to exist in that image. All `interval` / `timeout` / `retries` / `start_period` values are unchanged, and proxy-bypass prefixes are kept for the two services that inherit `x-proxy-env` (appsmith, lightrag).

## Per-service changes

| Service | Old probe | New probe | Why this tool |
|---|---|---|---|
| appsmith | `wget -qO- .../api/v1/health` | `curl -fsS .../api/v1/health` (proxy-bypass prefix kept) | Base image (`base.dockerfile`, Ubuntu 24.04) installs `curl`, not `wget` |
| gotenberg | `wget -qO /dev/null .../health` | `curl -fsS http://localhost:3000/health` | Gotenberg's Dockerfile installs `curl` explicitly "for Docker health checks" |
| databasus | `wget -qO- http://localhost:4005/` | `databasus healthcheck` (native command) | Image symlinks the app binary to `/usr/local/bin/databasus`; upstream's own compose uses exactly this check. Arch-independent, unlike the `-amd64` agent binary suggested in the issue comment (which would break arm64 hosts). `wget` is purged from the final image |
| comfyui | `wget -qO /dev/null http://localhost:8188` | `python3 -c "urllib.request.urlopen(..., timeout=5)"` | `cu128-slim` Dockerfile installs `python312` and sets the `python3` alternative; no curl or wget in its package list |
| lightrag | `wget -qO- .../health` | `python -c "urllib.request.urlopen(..., timeout=5)"` (proxy-bypass prefix kept) | Final stage is `python:3.12-slim-bookworm` with the venv `python` on PATH; no curl or wget in the final stage |
| paddleocr | `wget -qO- http://localhost:8080` | `wget -qO- http://localhost:8080/health` | `wget` provably exists here (the old check reached the server and got 404); only the endpoint was wrong — `/health` returns `{"errorCode":0,"errorMsg":"Healthy"}` |

## Verification

- Tool presence was verified against each image's upstream Dockerfile (Docker daemon not available locally for pulls):
  - `gotenberg/gotenberg` build/Dockerfile: installs `curl` in the common stage
  - `appsmithorg/appsmith` deploy/docker/base.dockerfile: `apt-get install ... curl ...`
  - `databasus/databasus` Dockerfile: `RUN ln -s /app/main /usr/local/bin/databasus`; `backend/cmd/healthcheck.go` implements the subcommand; the `latest` image on Docker Hub was pushed 2026-07-14, after the newest Dockerfile commit (2026-06-22), so the published image includes it
  - `YanWenKun/ComfyUI-Docker` archived/cu128-slim/Dockerfile: installs `python312`, no curl/wget
  - `HKUDS/LightRAG` Dockerfile: final stage `python:3.12-slim-bookworm`, only `gosu` added
- `docker compose -p localai config --quiet` passes with `.env` generated from `.env.example`
- Automated code review of the diff: no critical or important findings

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8