### PR TITLE
feat!: remove Hermes Agent from the stack (#88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,8 +181,6 @@ DIFY_HOSTNAME=dify.yourdomain.com
 DOCLING_HOSTNAME=docling.yourdomain.com
 FLOWISE_HOSTNAME=flowise.yourdomain.com
 GRAFANA_HOSTNAME=grafana.yourdomain.com
-HERMES_API_HOSTNAME=hermes-api.yourdomain.com
-HERMES_HOSTNAME=hermes.yourdomain.com
 INVOKEAI_HOSTNAME=invokeai.yourdomain.com
 LANGFUSE_HOSTNAME=langfuse.yourdomain.com
 LETTA_HOSTNAME=letta.yourdomain.com
@@ -515,7 +513,7 @@ GOST_UPSTREAM_PROXY=
 
 # Internal services bypass list (prevents internal Docker traffic from going through proxy)
 # Includes: Docker internal networks (172.16-31.*, 10.*), Docker DNS (127.0.0.11), and all service hostnames
-GOST_NO_PROXY=localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.local,appsmith,postgres,postgres:5432,redis,redis:6379,caddy,ollama,neo4j,qdrant,weaviate,clickhouse,minio,searxng,crawl4ai,gotenberg,langfuse-web,langfuse-worker,flowise,n8n,n8n-import,n8n-worker-1,n8n-worker-2,n8n-worker-3,n8n-worker-4,n8n-worker-5,n8n-worker-6,n8n-worker-7,n8n-worker-8,n8n-worker-9,n8n-worker-10,n8n-runner-1,n8n-runner-2,n8n-runner-3,n8n-runner-4,n8n-runner-5,n8n-runner-6,n8n-runner-7,n8n-runner-8,n8n-runner-9,n8n-runner-10,letta,hermes,lightrag,docling,postiz,temporal,temporal-ui,ragflow,ragflow-mysql,ragflow-minio,ragflow-redis,ragflow-elasticsearch,ragapp,open-webui,comfyui,invokeai,waha,libretranslate,paddleocr,nocodb,db,studio,kong,auth,rest,realtime,storage,imgproxy,meta,functions,analytics,vector,supavisor,gost,uptime-kuma,api.telegram.org,telegram.org,t.me,core.telegram.org
+GOST_NO_PROXY=localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.local,appsmith,postgres,postgres:5432,redis,redis:6379,caddy,ollama,neo4j,qdrant,weaviate,clickhouse,minio,searxng,crawl4ai,gotenberg,langfuse-web,langfuse-worker,flowise,n8n,n8n-import,n8n-worker-1,n8n-worker-2,n8n-worker-3,n8n-worker-4,n8n-worker-5,n8n-worker-6,n8n-worker-7,n8n-worker-8,n8n-worker-9,n8n-worker-10,n8n-runner-1,n8n-runner-2,n8n-runner-3,n8n-runner-4,n8n-runner-5,n8n-runner-6,n8n-runner-7,n8n-runner-8,n8n-runner-9,n8n-runner-10,letta,lightrag,docling,postiz,temporal,temporal-ui,ragflow,ragflow-mysql,ragflow-minio,ragflow-redis,ragflow-elasticsearch,ragapp,open-webui,comfyui,invokeai,waha,libretranslate,paddleocr,nocodb,db,studio,kong,auth,rest,realtime,storage,imgproxy,meta,functions,analytics,vector,supavisor,gost,uptime-kuma,api.telegram.org,telegram.org,t.me,core.telegram.org
 
 ############
 # Functions - Configuration for Functions
@@ -543,20 +541,6 @@ GOOGLE_PROJECT_NUMBER=GOOGLE_PROJECT_NUMBER
 
 # Letta
 LETTA_SERVER_PASSWORD=
-
-# Hermes Agent
-# Dashboard login (username = your install email; password/secret auto-generated).
-# LLM provider keys are NOT set here -
-# run 'docker compose -p localai run --rm hermes setup' or edit ./hermes/.env
-HERMES_USERNAME=
-HERMES_PASSWORD=
-HERMES_DASHBOARD_SECRET=
-# Bearer token for the OpenAI-compatible API (http://hermes:8642/v1)
-HERMES_API_SERVER_KEY=
-# UID/GID of the container user that owns ./hermes (chowned on container start;
-# set to your host user's UID/GID to edit ./hermes files directly)
-HERMES_UID=10000
-HERMES_GID=10000
 
 # Langsmith
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ Common profiles:
 - `dify`: Dify AI platform (external compose, cloned at runtime; mutually exclusive with `supabase`)
 - `gost`: HTTP/HTTPS proxy for routing AI service outbound traffic
 - `python-runner`: Internal Python execution environment (no external access)
-- `searxng`, `letta`, `hermes`, `lightrag`, `libretranslate`, `crawl4ai`, `docling`, `waha`, `comfyui`, `paddleocr`, `ragapp`, `gotenberg`, `postiz`: Additional optional services
+- `searxng`, `letta`, `lightrag`, `libretranslate`, `crawl4ai`, `docling`, `waha`, `comfyui`, `paddleocr`, `ragapp`, `gotenberg`, `postiz`: Additional optional services
 
 ## Architecture Patterns
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -148,21 +148,6 @@ import /etc/caddy/addons/tls-snippet.conf
     reverse_proxy letta:8283
 }
 
-# Hermes Agent dashboard (auth handled by Hermes itself - the dashboard fails
-# closed and won't serve unless an auth provider such as basic auth is configured)
-{$HERMES_HOSTNAME} {
-    import service_tls
-    reverse_proxy hermes:9119
-}
-
-# Hermes Agent OpenAI-compatible API - every API request must send
-# 'Authorization: Bearer <HERMES_API_SERVER_KEY>' (enforced by Hermes, /health
-# excepted; the API server refuses to start without a key)
-{$HERMES_API_HOSTNAME} {
-    import service_tls
-    reverse_proxy hermes:8642
-}
-
 # LightRAG (Graph-based RAG with Knowledge Extraction)
 {$LIGHTRAG_HOSTNAME} {
     import service_tls

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ The installer also makes the following powerful open-source tools **available fo
 
 ✅ [**Grafana**](https://grafana.com/) - An open-source platform for visualizing monitoring data, helping you understand system performance at a glance.
 
-✅ [**Hermes Agent**](https://github.com/NousResearch/hermes-agent) - An open-source autonomous AI agent by Nous Research with skills, persistent memory, MCP support, and multi-agent workflows. Includes a web dashboard and an OpenAI-compatible API that n8n workflows can call directly.
-
 ✅ [**InvokeAI**](https://invoke.ai/) - A professional creative engine for Stable Diffusion with a polished web UI, node-based workflow editor, inpainting/outpainting, and a REST API. Choose NVIDIA, AMD, or CPU hardware during install; models and outputs are stored in `./invokeai` on the host.
 
 ✅ [**Langfuse**](https://langfuse.com/) - An open-source platform to help you observe and understand how your AI agents are performing, making it easier to debug and improve them.
@@ -194,7 +192,6 @@ After successful installation, your services are up and running! Here's how to g
     - **Docling:** `docling.yourdomain.com` (Universal document converter with REST API; web UI available at `/ui`)
     - **Flowise:** `flowise.yourdomain.com` (Log in with the email address you provided during installation and the initial password from the summary report.)
     - **Grafana:** `grafana.yourdomain.com`
-    - **Hermes Agent:** `hermes.yourdomain.com` (Dashboard; log in with the email you provided during installation and the password from the Welcome Page. Requires an LLM provider key: run `docker compose -p localai run --rm hermes setup`. OpenAI-compatible API at `hermes-api.yourdomain.com/v1` with `Authorization: Bearer <HERMES_API_SERVER_KEY>`; internally at `http://hermes:8642/v1`. To let the agent manage Docker containers, mount `/var/run/docker.sock` into the `hermes` service via `docker-compose.override.yml` — off by default because it grants root-equivalent host access.)
     - **InvokeAI:** `invokeai.yourdomain.com` (Stable Diffusion studio; download a model via the Model Manager on first visit)
     - **Langfuse:** `langfuse.yourdomain.com`
     - **Letta:** `letta.yourdomain.com`

--- a/cloudflare-instructions.md
+++ b/cloudflare-instructions.md
@@ -117,8 +117,6 @@ After DNS is configured, go to **Cloudflare One Dashboard** → **Networks** →
 | **Docling**        | docling.yourdomain.com        | `http://docling:5001`        | ⚠️ Loses Caddy auth  |
 | **Flowise**        | flowise.yourdomain.com        | `http://flowise:3001`        | Built-in login      |
 | **Grafana**        | grafana.yourdomain.com        | `http://grafana:3000`        | Built-in login      |
-| **Hermes Agent**   | hermes.yourdomain.com         | `http://hermes:9119`         | Built-in login      |
-| **Hermes API**     | hermes-api.yourdomain.com     | `http://hermes:8642`         | Bearer token        |
 | **InvokeAI**       | invokeai.yourdomain.com       | `http://invokeai:9090`       | ⚠️ Loses Caddy auth  |
 | **Langfuse**       | langfuse.yourdomain.com       | `http://langfuse-web:3000`   | Built-in login      |
 | **Letta**          | letta.yourdomain.com          | `http://letta:8283`          | No auth             |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -368,8 +368,6 @@ services:
       DOCLING_USERNAME: "${DOCLING_USERNAME}"
       FLOWISE_HOSTNAME: "${FLOWISE_HOSTNAME}"
       GRAFANA_HOSTNAME: "${GRAFANA_HOSTNAME}"
-      HERMES_API_HOSTNAME: "${HERMES_API_HOSTNAME}"
-      HERMES_HOSTNAME: "${HERMES_HOSTNAME}"
       INVOKEAI_HOSTNAME: "${INVOKEAI_HOSTNAME}"
       INVOKEAI_PASSWORD_HASH: "${INVOKEAI_PASSWORD_HASH}"
       INVOKEAI_USERNAME: "${INVOKEAI_USERNAME}"
@@ -801,40 +799,6 @@ services:
       LETTA_SERVER_PASSWORD: "${LETTA_SERVER_PASSWORD:-}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
-  hermes:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes
-    profiles: ["hermes"]
-    restart: unless-stopped
-    logging: *default-logging
-    command: ["gateway", "run"]
-    volumes:
-      - ./hermes:/opt/data
-    environment:
-      <<: *proxy-env
-      HERMES_UID: "${HERMES_UID:-10000}"
-      HERMES_GID: "${HERMES_GID:-10000}"
-      # Web dashboard (port 9119) - runs supervised alongside the gateway.
-      # Hermes refuses to serve the dashboard on a non-loopback bind without
-      # an auth provider, so basic auth credentials are required.
-      HERMES_DASHBOARD: "1"
-      HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "${HERMES_USERNAME:-}"
-      HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "${HERMES_PASSWORD:-}"
-      HERMES_DASHBOARD_BASIC_AUTH_SECRET: "${HERMES_DASHBOARD_SECRET:-}"
-      # OpenAI-compatible API server (port 8642) - lets n8n call Hermes at
-      # http://hermes:8642/v1 with 'Authorization: Bearer <HERMES_API_SERVER_KEY>'.
-      # The server refuses to start without a key.
-      API_SERVER_ENABLED: "true"
-      API_SERVER_HOST: "0.0.0.0"
-      API_SERVER_KEY: "${HERMES_API_SERVER_KEY:-}"
-    healthcheck:
-      # Second probe checks the dashboard accepts connections (401 still passes,
-      # connection refused fails) - the two components can die independently
-      test: ["CMD-SHELL", "http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= curl -fsS http://localhost:8642/health && http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= curl -s -o /dev/null http://localhost:9119/ || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
 
   weaviate:
     image: cr.weaviate.io/semitechnologies/weaviate:latest

--- a/scripts/03_generate_secrets.sh
+++ b/scripts/03_generate_secrets.sh
@@ -47,7 +47,6 @@ EMAIL_VARS=(
     "COMFYUI_USERNAME"
     "DASHBOARD_USERNAME"
     "DOCLING_USERNAME"
-    "HERMES_USERNAME"
     "INVOKEAI_USERNAME"
     "LANGFUSE_INIT_USER_EMAIL"
     "LETSENCRYPT_EMAIL"
@@ -87,9 +86,6 @@ declare -A VARS_TO_GENERATE=(
     ["GOST_PASSWORD"]="password:32"
     ["GOST_USERNAME"]="fixed:gost"
     ["GRAFANA_ADMIN_PASSWORD"]="password:32"
-    ["HERMES_API_SERVER_KEY"]="secret:48" # Bearer token for Hermes OpenAI-compatible API
-    ["HERMES_DASHBOARD_SECRET"]="secret:64" # Session secret for Hermes dashboard basic auth
-    ["HERMES_PASSWORD"]="password:32" # Hermes dashboard basic auth password
     ["INVOKEAI_PASSWORD"]="password:32" # InvokeAI Caddy basic auth password
     ["JWT_SECRET"]="base64:64" # 48 bytes -> 64 chars
     ["LANGFUSE_INIT_PROJECT_PUBLIC_KEY"]="langfuse_pk:32"

--- a/scripts/04_wizard.sh
+++ b/scripts/04_wizard.sh
@@ -48,7 +48,6 @@ base_services_data=(
     "flowise" "Flowise (AI Agent Builder)"
     "gost" "Gost Proxy (HTTP/HTTPS proxy for AI services outbound traffic)"
     "gotenberg" "Gotenberg (Document Conversion API)"
-    "hermes" "Hermes Agent (Autonomous AI agent: skills, memory, MCP)"
     "invokeai" "InvokeAI (Stable Diffusion Studio - select hardware in next step)"
     "langfuse" "Langfuse Suite (AI Observability - includes Clickhouse, Minio)"
     "letta" "Letta (Agent Server & SDK)"

--- a/scripts/07_final_report.sh
+++ b/scripts/07_final_report.sh
@@ -106,9 +106,6 @@ fi
 if is_profile_active "uptime-kuma"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Uptime Kuma${NC}: Create your account on first login"
 fi
-if is_profile_active "hermes"; then
-    echo -e "     ${GREEN}*${NC} ${WHITE}Hermes Agent${NC}: Set an LLM provider key first: 'docker compose -p localai run --rm hermes setup' (or edit ./hermes/.env)"
-fi
 if is_profile_active "gost"; then
     echo -e "     ${GREEN}*${NC} ${WHITE}Gost Proxy${NC}: Routing AI traffic through external proxy"
 fi

--- a/scripts/apply_update.sh
+++ b/scripts/apply_update.sh
@@ -83,6 +83,9 @@ log_success "Service configuration completed."
 cleanup_legacy_n8n_workers
 cleanup_legacy_postgresus
 
+# Clean up services removed from the stack
+cleanup_removed_hermes
+
 # Pull latest versions of selected containers based on updated .env
 set_telemetry_stage "update_docker_pull"
 log_info "Pulling latest versions of selected containers..."

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -72,17 +72,6 @@ if [ -f "$ENV_FILE" ]; then
         fi
     fi
 
-    # Hermes API server refuses to start without a key while the gateway and
-    # dashboard keep running, so an empty key half-kills the container: n8n
-    # calls to http://hermes:8642/v1 get connection refused with no error
-    # surfaced anywhere except the container flipping to unhealthy.
-    if is_profile_active "hermes"; then
-        if [ -n "$HERMES_API_SERVER_KEY" ]; then
-            count_ok "HERMES_API_SERVER_KEY is set (Hermes OpenAI-compatible API can start)"
-        else
-            count_error "hermes profile is active but HERMES_API_SERVER_KEY is empty — the Hermes API server will not start (connection refused on port 8642). Run 'make update' to regenerate the key."
-        fi
-    fi
 else
     count_error ".env file not found at $ENV_FILE"
     print_info "Run 'make install' to set up the environment."

--- a/scripts/generate_welcome_page.sh
+++ b/scripts/generate_welcome_page.sh
@@ -272,23 +272,6 @@ if is_profile_active "letta"; then
     }")
 fi
 
-# Hermes Agent
-if is_profile_active "hermes"; then
-    SERVICES_ARRAY+=("    \"hermes\": {
-      \"hostname\": \"$(json_escape "$HERMES_HOSTNAME")\",
-      \"credentials\": {
-        \"username\": \"$(json_escape "$HERMES_USERNAME")\",
-        \"password\": \"$(json_escape "$HERMES_PASSWORD")\",
-        \"api_key\": \"$(json_escape "$HERMES_API_SERVER_KEY")\"
-      },
-      \"extra\": {
-        \"internal_api\": \"http://hermes:8642/v1\",
-        \"api_endpoint\": \"https://$(json_escape "$HERMES_API_HOSTNAME")/v1\",
-        \"docs\": \"https://github.com/NousResearch/hermes-agent\"
-      }
-    }")
-fi
-
 # ComfyUI
 if is_profile_active "comfyui"; then
     SERVICES_ARRAY+=("    \"comfyui\": {
@@ -570,16 +553,6 @@ if is_profile_active "databasus"; then
       \"step\": $STEP_NUM,
       \"title\": \"Configure database backups\",
       \"description\": \"Set up Databasus for automated database backups\"
-    }")
-    ((STEP_NUM++))
-fi
-
-# Configure Hermes Agent (if hermes active)
-if is_profile_active "hermes"; then
-    QUICK_START_ARRAY+=("    {
-      \"step\": $STEP_NUM,
-      \"title\": \"Configure Hermes Agent\",
-      \"description\": \"Set an LLM provider key: 'docker compose -p localai run --rm hermes setup' (or edit ./hermes/.env)\"
     }")
     ((STEP_NUM++))
 fi

--- a/scripts/update_preview.sh
+++ b/scripts/update_preview.sh
@@ -130,11 +130,6 @@ elif is_profile_active "invokeai-cpu"; then
     check_image_update "invokeai" "ghcr.io/invoke-ai/invokeai:main-cpu"
 fi
 
-if is_profile_active "hermes"; then
-    log_subheader "Hermes Agent"
-    check_image_update "hermes" "nousresearch/hermes-agent:latest"
-fi
-
 if is_profile_active "qdrant"; then
     log_subheader "Qdrant"
     check_image_update "qdrant" "qdrant/qdrant:latest"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -739,6 +739,14 @@ cleanup_removed_hermes() {
         docker rm -f "$container_name" 2>/dev/null || true
         log_success "Hermes container removed. Your data in ./hermes is left untouched."
     fi
+
+    # A leftover hermes block in docker-compose.override.yml (the old README
+    # suggested one for the docker.sock mount) now breaks 'docker compose'
+    # because the base service no longer exists - warn with the actual fix
+    local override_file="$PROJECT_ROOT/docker-compose.override.yml"
+    if [ -f "$override_file" ] && grep -Eq '^[[:space:]]+hermes:[[:space:]]*$' "$override_file"; then
+        log_warning "docker-compose.override.yml contains a 'hermes:' service block, but Hermes was removed from the stack. Delete that block from the file, or 'docker compose' commands will fail."
+    fi
 }
 
 #=============================================================================

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -713,6 +713,34 @@ cleanup_legacy_postgresus() {
     fi
 }
 
+# Clean up the Hermes Agent service removed from the stack (issue #88)
+# Drops the 'hermes' profile from COMPOSE_PROFILES and removes the container.
+# User data in ./hermes is intentionally left untouched.
+# Usage: cleanup_removed_hermes
+cleanup_removed_hermes() {
+    local container_name="hermes"
+
+    # Drop the profile from .env if still present
+    local profiles
+    profiles=$(read_env_var "COMPOSE_PROFILES")
+    if [[ ",${profiles}," == *",hermes,"* ]]; then
+        local new_profiles=",${profiles},"
+        new_profiles="${new_profiles//,hermes,/,}"
+        new_profiles="${new_profiles#,}"
+        new_profiles="${new_profiles%,}"
+        update_compose_profiles "$new_profiles"
+        log_info "Removed 'hermes' from COMPOSE_PROFILES (Hermes Agent is no longer part of the stack)."
+    fi
+
+    # Remove the container if it exists (running or stopped)
+    if docker ps -a --format '{{.Names}}' | grep -q "^${container_name}$"; then
+        log_info "Removing Hermes Agent container (service removed from the stack)..."
+        docker stop "$container_name" 2>/dev/null || true
+        docker rm -f "$container_name" 2>/dev/null || true
+        log_success "Hermes container removed. Your data in ./hermes is left untouched."
+    fi
+}
+
 #=============================================================================
 # USER DETECTION
 #=============================================================================

--- a/welcome/app.js
+++ b/welcome/app.js
@@ -308,14 +308,6 @@
             category: 'ai',
             docsUrl: 'https://docs.letta.com'
         },
-        'hermes': {
-            name: 'Hermes Agent',
-            description: 'Autonomous AI agent with skills, memory & MCP',
-            icon: 'HA',
-            color: 'bg-amber-500',
-            category: 'ai',
-            docsUrl: 'https://github.com/NousResearch/hermes-agent'
-        },
         'comfyui': {
             name: 'ComfyUI',
             description: 'Stable Diffusion UI',


### PR DESCRIPTION
# Summary

This PR removes the Hermes Agent service from the stack completely. This is a breaking change: the `hermes` profile, its Caddy routes, and its environment variables are gone.

# Rationale

Hermes is an infrastructure-level agent. It manages, monitors, and interacts with the stack itself: Docker containers, logs, databases, MCP servers, and the host system. Running it inside the stack it manages is a design mistake:

- **Security boundary** — Hermes holds credentials and needs elevated permissions. Running it inside the managed environment blurs the separation of responsibilities. Keeping it outside creates a cleaner boundary and reduces blast radius.
- **Circular dependency** — a management agent should not depend on the environment it controls. Inside the stack, the management layer goes down together with the workloads it is supposed to manage.
- **Reliability and operational independence** — Hermes should stay available while the stack is unhealthy or being updated. Bundling a heavily customized agent with the stack makes every update riskier.

Users who want Hermes can deploy it separately, following their own security model.

# Removal checklist

- `docker-compose.yml` — `hermes` service block and the two `HERMES_*` hostname variables passed to Caddy
- `Caddyfile` — dashboard block (`{$HERMES_HOSTNAME}` → `hermes:9119`) and API block (`{$HERMES_API_HOSTNAME}` → `hermes:8642`)
- `.env.example` — `HERMES_HOSTNAME`, `HERMES_API_HOSTNAME`, the whole `HERMES_*` credentials block, and the `hermes` entry in `GOST_NO_PROXY`
- `scripts/03_generate_secrets.sh` — `HERMES_USERNAME` in `EMAIL_VARS`; `HERMES_API_SERVER_KEY`, `HERMES_DASHBOARD_SECRET`, `HERMES_PASSWORD` in `VARS_TO_GENERATE`
- `scripts/04_wizard.sh` — service selection entry
- `scripts/05_configure_services.sh` — no Hermes references (verified)
- `scripts/07_final_report.sh` — post-install note
- `scripts/doctor.sh` — `HERMES_API_SERVER_KEY` diagnostic
- `scripts/update_preview.sh` — image update check
- `scripts/generate_welcome_page.sh` — services entry and quick-start step
- `welcome/app.js` — `SERVICE_METADATA` entry
- `README.md`, `CLAUDE.md`, `cloudflare-instructions.md` — all mentions

`CHANGELOG.md` history is untouched, and `.gitignore` keeps the `hermes/` entry so leftover data directories stay ignored (see below).

# Migration for existing users

`make update` now runs a one-time cleanup (`cleanup_removed_hermes` in `scripts/utils.sh`, wired into `scripts/apply_update.sh` next to the existing legacy-container cleanups):

1. Removes `hermes` from `COMPOSE_PROFILES` in `.env` if it is still there.
2. Stops and removes the `hermes` container if it exists.
3. Warns if `docker-compose.override.yml` still contains a `hermes:` service block (the old README suggested one for the docker.sock mount) — such a block would now make `docker compose` fail, so the warning tells the user exactly what to delete.

**No user data is deleted.** The `./hermes` directory (agent config, memory, `.env` with LLM provider keys) is left on disk, so users who move Hermes to a standalone deployment can take their data with them.

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8
