### PR TITLE
fix: preserve user .env variables during --update (#90)

### DIFF
--- a/scripts/03_generate_secrets.sh
+++ b/scripts/03_generate_secrets.sh
@@ -546,10 +546,12 @@ done
 # Variables that exist in the current .env but were not written by the template
 # pass above (custom user variables, uncommented opt-ins like SCARF_ANALYTICS,
 # INSTALLATION_ID from telemetry.sh) would otherwise be silently dropped.
-# Append them under a marked section. The section is rebuilt on every run, so
-# repeated updates never duplicate entries. This runs before the WAHA/GOST/hash
-# blocks below so intentional removals (e.g. GOST_PROXY_URL when the gost
-# profile is disabled) still take effect afterwards.
+# Append them under a marked section. The whole .env was regenerated from the
+# template above, so the previous run's section is already gone and repeated
+# updates never duplicate entries. This block must run before the WAHA/GOST/hash
+# blocks below: they intentionally remove some variables (e.g. GOST_PROXY_URL
+# when the gost profile is disabled), and running after them would re-append
+# the removed values.
 preserved_header_written=0
 while IFS= read -r varName; do
     # Only preserve valid variable names; skips garbage from malformed lines
@@ -559,6 +561,7 @@ while IFS= read -r varName; do
             {
                 echo ""
                 echo "# --- Preserved user variables (not in template) ---"
+                echo "# Note: the installer also re-appends its own managed variables below this line"
             } >> "$OUTPUT_FILE"
             preserved_header_written=1
         fi

--- a/scripts/03_generate_secrets.sh
+++ b/scripts/03_generate_secrets.sh
@@ -542,6 +542,38 @@ for key in "${!generated_values[@]}"; do
     rm -f "$value_file"
 done
 
+# --- Preserve variables not present in the template ---
+# Variables that exist in the current .env but were not written by the template
+# pass above (custom user variables, uncommented opt-ins like SCARF_ANALYTICS,
+# INSTALLATION_ID from telemetry.sh) would otherwise be silently dropped.
+# Append them under a marked section. The section is rebuilt on every run, so
+# repeated updates never duplicate entries. This runs before the WAHA/GOST/hash
+# blocks below so intentional removals (e.g. GOST_PROXY_URL when the gost
+# profile is disabled) still take effect afterwards.
+preserved_header_written=0
+while IFS= read -r varName; do
+    # Only preserve valid variable names; skips garbage from malformed lines
+    [[ "$varName" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    if ! grep -q "^${varName}=" "$OUTPUT_FILE"; then
+        if [[ $preserved_header_written -eq 0 ]]; then
+            {
+                echo ""
+                echo "# --- Preserved user variables (not in template) ---"
+            } >> "$OUTPUT_FILE"
+            preserved_header_written=1
+        fi
+        varValue="${existing_env_vars[$varName]}"
+        # Use single quotes for values containing $ (like bcrypt hashes) to
+        # prevent variable expansion, same as _update_or_add_env_var
+        if [[ "$varValue" == *'$'* ]]; then
+            echo "${varName}='${varValue}'" >> "$OUTPUT_FILE"
+        else
+            echo "${varName}=\"${varValue}\"" >> "$OUTPUT_FILE"
+        fi
+        log_info "Preserved variable not present in template: $varName"
+    fi
+done < <(printf '%s\n' "${!existing_env_vars[@]}" | sort)
+
 # --- WAHA API KEY (sha512) --- ensure after .env write/substitutions ---
 # Generate plaintext API key if missing, then compute sha512:HEX and store in WAHA_API_KEY
 if [[ -z "${generated_values[WAHA_API_KEY_PLAIN]}" ]]; then


### PR DESCRIPTION
## Summary

`scripts/03_generate_secrets.sh` rebuilds `.env` by iterating `.env.example` line by line. Any variable that existed in `.env` but not in the template was silently dropped on every `make update` / `make git-pull`: custom user variables, uncommented opt-ins (`SCARF_ANALYTICS`, `GOOGLE_*`, `SEARXNG_UWSGI_*`), and `INSTALLATION_ID` (which made telemetry identity churn on each update).

## What changed

After the template and substitution passes, the script now appends every variable from the old `.env` that is missing from the newly built file, under a marked section:

```
# --- Preserved user variables (not in template) ---
```

Details:
- The pass runs before the WAHA/GOST/password-hash blocks, so intentional removals (e.g. `GOST_PROXY_URL` when the gost profile is disabled) still take effect.
- Idempotent: `.env` is fully regenerated from the template each run, so the section never accumulates duplicates across repeated updates.
- Variable names are validated (`[A-Za-z_][A-Za-z0-9_]*`) so parse garbage from malformed lines is not resurrected.
- Values containing `$` (e.g. bcrypt hashes) use single quotes, matching the existing `_update_or_add_env_var` convention.
- No-op on fresh installs (no prior `.env`), so it is safe to run unconditionally — no new flag parsing needed.
- The empty-value removal in `_update_or_add_env_var` is left unchanged: it is intentional (clearing `GOST_PROXY_URL` when gost is off).

## How it was verified

- `bash -n scripts/03_generate_secrets.sh` passes.
- Functional test (bash 5, Ubuntu-only commands shimmed): built `.env` from `.env.example` plus `CUSTOM_VAR=hello`, `INSTALLATION_ID="test-id"`, `SCARF_ANALYTICS=false`, and a value containing `$` signs, then ran `--update` twice.
  - Baseline (unpatched): `CUSTOM_VAR` deleted, `INSTALLATION_ID` regenerated to a new random id — reproduces the issue.
  - Patched: all variables survive with exact values, appear exactly once, one section header, and the two consecutive runs produce identical `.env` assignments (full idempotency, no secret churn).
- Multi-agent code review found no critical or important functional issues; comment-accuracy findings were addressed in a follow-up commit.

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8