### PR TITLE
feat: optional GPU device pinning for Ollama and InvokeAI (#83)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -703,21 +703,31 @@ DOCLING_DEVICE=cpu
 # Ollama configuration
 # OLLAMA_GPU_COUNT: Number of NVIDIA GPUs reserved for Ollama (gpu-nvidia profile only).
 # Set to a number (e.g. 2) or "all" to use every available GPU.
-# Ignored by the CPU and AMD variants.
+# OLLAMA_GPU_DEVICES: Pin Ollama to specific NVIDIA GPU IDs on multi-GPU hosts,
+# e.g. OLLAMA_GPU_DEVICES=1,2 (comma-separated, no spaces; GPU UUIDs also work).
+# When set, it takes precedence over OLLAMA_GPU_COUNT. Leave empty to keep the
+# count-based behavior. Applied on the next make restart / make update.
+# Both are ignored by the CPU and AMD variants.
 ############
 OLLAMA_GPU_COUNT=1
+OLLAMA_GPU_DEVICES=
 
 ############
 # [optional]
 # InvokeAI configuration
 # INVOKEAI_GPU_COUNT: Number of NVIDIA GPUs reserved for InvokeAI (invokeai-nvidia
 # profile only). Set to a number (e.g. 2) or "all" to use every available GPU.
-# Ignored by the CPU and AMD variants.
+# INVOKEAI_GPU_DEVICES: Pin InvokeAI to specific NVIDIA GPU IDs on multi-GPU hosts,
+# e.g. INVOKEAI_GPU_DEVICES=0 (comma-separated, no spaces; GPU UUIDs also work).
+# When set, it takes precedence over INVOKEAI_GPU_COUNT. Leave empty to keep the
+# count-based behavior. Applied on the next make restart / make update.
+# Both are ignored by the CPU and AMD variants.
 # RENDER_GROUP_ID: Host GID of the "render" group, required for the AMD (ROCm) variant
 # to access /dev/kfd and /dev/dri. Find it with: getent group render | cut -d: -f3
 # Leave RENDER_GROUP_ID empty for the NVIDIA/CPU variants.
 ############
 INVOKEAI_GPU_COUNT=1
+INVOKEAI_GPU_DEVICES=
 RENDER_GROUP_ID=
 
 ##########################################################################################

--- a/docker-compose.invokeai-gpu-devices.yml
+++ b/docker-compose.invokeai-gpu-devices.yml
@@ -1,0 +1,19 @@
+# GPU pinning override for InvokeAI (NVIDIA only).
+#
+# This file is included automatically by the stack's scripts when
+# INVOKEAI_GPU_DEVICES is set to a non-empty value in .env (for example
+# INVOKEAI_GPU_DEVICES=0). It replaces the count-based GPU reservation of the
+# invokeai-nvidia service with an explicit list of GPU device IDs, so InvokeAI
+# only sees the listed GPUs. When INVOKEAI_GPU_DEVICES is empty, this file is
+# not used and INVOKEAI_GPU_COUNT keeps working as before.
+#
+# Requires Docker Compose v2.24.4+ (for the !override tag).
+services:
+  invokeai-nvidia:
+    deploy:
+      resources:
+        reservations:
+          devices: !override
+            - driver: nvidia
+              device_ids: ["${INVOKEAI_GPU_DEVICES:?set INVOKEAI_GPU_DEVICES in .env, e.g. 0}"]
+              capabilities: [gpu]

--- a/docker-compose.ollama-gpu-devices.yml
+++ b/docker-compose.ollama-gpu-devices.yml
@@ -1,0 +1,19 @@
+# GPU pinning override for Ollama (NVIDIA only).
+#
+# This file is included automatically by the stack's scripts when
+# OLLAMA_GPU_DEVICES is set to a non-empty value in .env (for example
+# OLLAMA_GPU_DEVICES=1,2). It replaces the count-based GPU reservation of the
+# ollama-gpu service with an explicit list of GPU device IDs, so Ollama only
+# sees the listed GPUs. When OLLAMA_GPU_DEVICES is empty, this file is not
+# used and OLLAMA_GPU_COUNT keeps working as before.
+#
+# Requires Docker Compose v2.24.4+ (for the !override tag).
+services:
+  ollama-gpu:
+    deploy:
+      resources:
+        reservations:
+          devices: !override
+            - driver: nvidia
+              device_ids: ["${OLLAMA_GPU_DEVICES:?set OLLAMA_GPU_DEVICES in .env, e.g. 1,2}"]
+              capabilities: [gpu]

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -88,6 +88,12 @@ MAIN_COMPOSE_FILES=("-f" "$PROJECT_ROOT/docker-compose.yml")
 if path=$(get_n8n_workers_compose); then
     MAIN_COMPOSE_FILES+=("-f" "$path")
 fi
+if path=$(get_ollama_gpu_devices_compose); then
+    MAIN_COMPOSE_FILES+=("-f" "$path")
+fi
+if path=$(get_invokeai_gpu_devices_compose); then
+    MAIN_COMPOSE_FILES+=("-f" "$path")
+fi
 OVERRIDE_COMPOSE="$PROJECT_ROOT/docker-compose.override.yml"
 if [ -f "$OVERRIDE_COMPOSE" ]; then
     MAIN_COMPOSE_FILES+=("-f" "$OVERRIDE_COMPOSE")

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -8,6 +8,8 @@
 # Handles compose files via build_compose_files_array() from utils.sh:
 #   - docker-compose.yml (main)
 #   - docker-compose.n8n-workers.yml (if exists and n8n profile active)
+#   - docker-compose.ollama-gpu-devices.yml (if gpu-nvidia profile active and OLLAMA_GPU_DEVICES set)
+#   - docker-compose.invokeai-gpu-devices.yml (if invokeai-nvidia profile active and INVOKEAI_GPU_DEVICES set)
 #   - supabase/docker/docker-compose.yml (if exists and supabase profile active)
 #   - dify/docker/docker-compose.yaml (if exists and dify profile active)
 #   - docker-compose.override.yml (if exists, user overrides with highest precedence)

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -390,9 +390,13 @@ build_compose_files_array() {
     fi
     if path=$(get_ollama_gpu_devices_compose); then
         COMPOSE_FILES+=("-f" "$path")
+    elif [ -n "${OLLAMA_GPU_DEVICES:-}" ]; then
+        log_warning "OLLAMA_GPU_DEVICES is set but GPU pinning is NOT applied (requires the gpu-nvidia profile and docker-compose.ollama-gpu-devices.yml)"
     fi
     if path=$(get_invokeai_gpu_devices_compose); then
         COMPOSE_FILES+=("-f" "$path")
+    elif [ -n "${INVOKEAI_GPU_DEVICES:-}" ]; then
+        log_warning "INVOKEAI_GPU_DEVICES is set but GPU pinning is NOT applied (requires the invokeai-nvidia profile and docker-compose.invokeai-gpu-devices.yml)"
     fi
     if path=$(get_supabase_compose); then
         COMPOSE_FILES+=("-f" "$path")

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -330,6 +330,30 @@ get_n8n_workers_compose() {
     return 1
 }
 
+# Get Ollama GPU pinning compose file path if the gpu-nvidia profile is active
+# and OLLAMA_GPU_DEVICES has a non-empty value (requires load_env first)
+# Usage: path=$(get_ollama_gpu_devices_compose) && COMPOSE_FILES+=("-f" "$path")
+get_ollama_gpu_devices_compose() {
+    local compose_file="$PROJECT_ROOT/docker-compose.ollama-gpu-devices.yml"
+    if [ -f "$compose_file" ] && is_profile_active "gpu-nvidia" && [ -n "${OLLAMA_GPU_DEVICES:-}" ]; then
+        echo "$compose_file"
+        return 0
+    fi
+    return 1
+}
+
+# Get InvokeAI GPU pinning compose file path if the invokeai-nvidia profile is
+# active and INVOKEAI_GPU_DEVICES has a non-empty value (requires load_env first)
+# Usage: path=$(get_invokeai_gpu_devices_compose) && COMPOSE_FILES+=("-f" "$path")
+get_invokeai_gpu_devices_compose() {
+    local compose_file="$PROJECT_ROOT/docker-compose.invokeai-gpu-devices.yml"
+    if [ -f "$compose_file" ] && is_profile_active "invokeai-nvidia" && [ -n "${INVOKEAI_GPU_DEVICES:-}" ]; then
+        echo "$compose_file"
+        return 0
+    fi
+    return 1
+}
+
 # Get Supabase compose file path if profile is active and file exists
 # Usage: path=$(get_supabase_compose) && COMPOSE_FILES+=("-f" "$path")
 get_supabase_compose() {
@@ -362,6 +386,12 @@ build_compose_files_array() {
 
     local path
     if path=$(get_n8n_workers_compose); then
+        COMPOSE_FILES+=("-f" "$path")
+    fi
+    if path=$(get_ollama_gpu_devices_compose); then
+        COMPOSE_FILES+=("-f" "$path")
+    fi
+    if path=$(get_invokeai_gpu_devices_compose); then
         COMPOSE_FILES+=("-f" "$path")
     fi
     if path=$(get_supabase_compose); then

--- a/start_services.py
+++ b/start_services.py
@@ -28,6 +28,17 @@ def is_dify_enabled():
     compose_profiles = env_values.get("COMPOSE_PROFILES", "")
     return "dify" in compose_profiles.split(',')
 
+def get_gpu_devices_compose_files():
+    """Return GPU pinning override files for services with *_GPU_DEVICES set in .env."""
+    env_values = dotenv_values(".env")
+    profiles = env_values.get("COMPOSE_PROFILES", "").split(',')
+    files = []
+    if "gpu-nvidia" in profiles and env_values.get("OLLAMA_GPU_DEVICES"):
+        files.append("docker-compose.ollama-gpu-devices.yml")
+    if "invokeai-nvidia" in profiles and env_values.get("INVOKEAI_GPU_DEVICES"):
+        files.append("docker-compose.invokeai-gpu-devices.yml")
+    return [f for f in files if os.path.exists(f)]
+
 def get_all_profiles(compose_file):
     """Get all profile names from a docker-compose file."""
     if not os.path.exists(compose_file):
@@ -411,6 +422,10 @@ def start_local_ai():
     n8n_workers_compose_path = "docker-compose.n8n-workers.yml"
     if os.path.exists(n8n_workers_compose_path):
         compose_files.extend(["-f", n8n_workers_compose_path])
+
+    # Include GPU pinning overrides when *_GPU_DEVICES is set in .env
+    for gpu_devices_compose_path in get_gpu_devices_compose_files():
+        compose_files.extend(["-f", gpu_devices_compose_path])
 
     # Include user overrides if present (must be last for highest precedence)
     override_path = "docker-compose.override.yml"

--- a/start_services.py
+++ b/start_services.py
@@ -33,11 +33,18 @@ def get_gpu_devices_compose_files():
     env_values = dotenv_values(".env")
     profiles = env_values.get("COMPOSE_PROFILES", "").split(',')
     files = []
-    if "gpu-nvidia" in profiles and env_values.get("OLLAMA_GPU_DEVICES"):
-        files.append("docker-compose.ollama-gpu-devices.yml")
-    if "invokeai-nvidia" in profiles and env_values.get("INVOKEAI_GPU_DEVICES"):
-        files.append("docker-compose.invokeai-gpu-devices.yml")
-    return [f for f in files if os.path.exists(f)]
+    for var, profile, compose_file in [
+        ("OLLAMA_GPU_DEVICES", "gpu-nvidia", "docker-compose.ollama-gpu-devices.yml"),
+        ("INVOKEAI_GPU_DEVICES", "invokeai-nvidia", "docker-compose.invokeai-gpu-devices.yml"),
+    ]:
+        if not env_values.get(var):
+            continue
+        if profile in profiles and os.path.exists(compose_file):
+            files.append(compose_file)
+        else:
+            print(f"Warning: {var} is set but GPU pinning is NOT applied "
+                  f"(requires the {profile} profile and {compose_file}).")
+    return files
 
 def get_all_profiles(compose_file):
     """Get all profile names from a docker-compose file."""


### PR DESCRIPTION
## Summary

On multi-GPU hosts, users can now pin Ollama and InvokeAI to specific NVIDIA GPU IDs instead of only choosing how many GPUs to use. Two new optional variables in `.env`:

```env
OLLAMA_GPU_DEVICES=1,2
INVOKEAI_GPU_DEVICES=0
```

When a variable is set, it takes precedence over the matching `*_GPU_COUNT`. When it is empty (the default), nothing changes.

## How it works

Docker Compose does not allow `count` and `device_ids` in the same GPU reservation, and a user-set `NVIDIA_VISIBLE_DEVICES` env var is always overridden by the reservation (the daemon appends its own value after the container env). So pinning is implemented as two small checked-in override files:

- `docker-compose.ollama-gpu-devices.yml`
- `docker-compose.invokeai-gpu-devices.yml`

Each uses the Compose `!override` tag to replace the count-based reservation with `device_ids: ["${..._GPU_DEVICES}"]`. The Docker daemon joins `device_ids` with commas into `NVIDIA_VISIBLE_DEVICES`, so a single `"1,2"` element is equivalent to a real list. The scripts (`build_compose_files_array()` in `utils.sh`, plus `start_services.py` and `restart.sh`) include a file automatically only when the matching profile (`gpu-nvidia` / `invokeai-nvidia`) is active AND the variable is non-empty. If a variable is set but the conditions are not met, a clear warning is printed instead of silently skipping.

Pinning applies to the NVIDIA variants only. The AMD variants use `/dev/kfd` + `/dev/dri` device passthrough, where per-GPU selection works differently, and the CPU variants have no GPUs. ComfyUI is CPU-only in this stack, so it is out of scope.

## Usage

```bash
# .env
OLLAMA_GPU_DEVICES=1,2    # Ollama only sees GPUs 1 and 2
INVOKEAI_GPU_DEVICES=0    # InvokeAI only sees GPU 0

make restart              # or make update
```

GPU UUIDs also work. Clearing the variables reverts to the count-based behavior on the next restart/update.

## Backward compatibility

Fully backward compatible. With the new variables empty or absent, no override file is included and the rendered compose config is byte-identical to before (`count: "${OLLAMA_GPU_COUNT:-1}"` / `count: "${INVOKEAI_GPU_COUNT:-1}"`). Existing `*_GPU_COUNT` settings keep working unchanged. The new variables are added to existing `.env` files automatically on the next `make update` (empty by default). Requires Docker Compose v2.24.4+ only when pinning is actually used (for the `!override` tag).

## Verification

Tested on macOS with Docker Compose v5.3.0 (no NVIDIA GPU available on this machine, so verification is via rendered config plus the Docker daemon source, which shows `device_ids` are comma-joined into `NVIDIA_VISIBLE_DEVICES`):

- `docker compose config` with vars unset: both services render `count: 1` exactly as on develop.
- With `OLLAMA_GPU_DEVICES=1,2` and `INVOKEAI_GPU_DEVICES=0`: services render `device_ids: ["1,2"]` / `device_ids: ["0"]` with the count reservation fully replaced.
- `build_compose_files_array()` and `get_gpu_devices_compose_files()` tested in all states: both vars set, one set, none set, var set with profile inactive (warning printed, file skipped).
- `bash -n` on all touched scripts and `docker compose config --quiet` pass in both modes.

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upb4vzvyyKNcowbTeBMLP8